### PR TITLE
install .pc files in libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ endif()
 # TODO: Add support for relocatable packages.
 configure_file ( libhsakmt.pc.in libhsakmt.pc @ONLY )
 
-install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/libhsakmt.pc DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig COMPONENT devel)
+install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/libhsakmt.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT devel)
 
 ###########################
 # Packaging directives


### PR DESCRIPTION
Provided pkgconfig file contains interface description which is arch dependent.
In such cases .pc files should be installed in libdir.