### PR TITLE
kfdtest: link llvm dynamic lib; fix hsaKmtCheckRuntimeDebugSupport visibility

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -268,7 +268,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDbgAddressWatch(HSAuint32 NodeId,
 #define HSA_RUNTIME_ENABLE_MAX_MAJOR   1
 #define HSA_RUNTIME_ENABLE_MIN_MINOR   13
 
-HSAKMT_STATUS hsaKmtCheckRuntimeDebugSupport(void) {
+HSAKMT_STATUS HSAKMTAPI hsaKmtCheckRuntimeDebugSupport(void) {
 	HsaNodeProperties node = {0};
 	HsaSystemProperties props = {0};
 	HsaVersionInfo versionInfo = {0};

--- a/tests/kfdtest/CMakeLists.txt
+++ b/tests/kfdtest/CMakeLists.txt
@@ -154,7 +154,11 @@ include_directories(${LLVM_INCLUDE_DIRS})
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 add_definitions(${LLVM_DEFINITIONS_LIST})
 
-llvm_map_components_to_libnames(llvm_libs AMDGPUAsmParser Core Support)
+if (LLVM_LINK_LLVM_DYLIB)
+  set(llvm_libs LLVM)
+else()
+  llvm_map_components_to_libnames(llvm_libs AMDGPUAsmParser Core Support)
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/gtest-1.6.0)
 include_directories(${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
1. Distros like Gentoo use dynamic libLLVM.so instead of separated, static llvm component libs. Add a switch to choose linking  libLLVM.so.

2. kfdtest cannot be built due to: 

```
mold: error: undefined symbol: hsaKmtCheckRuntimeDebugSupport                                                                                                                                                      
>>> referenced by KFDDBGTest.cpp                                                                                                                                                                                   
>>>               CMakeFiles/kfdtest.dir/src/KFDDBGTest.cpp.o:(KFDDBGTest_AttachToSpawnedProcess_Test::TestBody())>>> referenced by KFDDBGTest.cpp
>>>               CMakeFiles/kfdtest.dir/src/KFDDBGTest.cpp.o:(KFDDBGTest_AttachToRunningProcess_Test::TestBody())>>> referenced by KFDDBGTest.cpp
>>>               CMakeFiles/kfdtest.dir/src/KFDDBGTest.cpp.o:(KFDDBGTest_HitTrapEvent_Test::TestBody())>>> referenced 4 more times

collect2: error: ld returned 1 exit status
```

Turns out hsaKmtCheckRuntimeDebugSupport is a hidden symbol. Fix that to make kfdtest build successfully